### PR TITLE
Feat: Add submissions api to arbiter agent

### DIFF
--- a/Demo/app/api/submissions/Readme.md
+++ b/Demo/app/api/submissions/Readme.md
@@ -41,23 +41,31 @@ The API requires MongoDB for project validation and finding storage.
 mongo --eval "db.version()" || mongosh --eval "db.version()"
 ```
 
+Make sure to add `seed_data` to mongoDB for testing purposes by running `python seed_data.py` from submissions directory.
+
 4. **Integrate with arbiter agent code**
 
-This API is designed to be integrated directly with the arbiter agent codebase. Ensure that the arbiter agent's modules (particularly `app.core.cross_agent_comparison`) are available in the Python path.
+This API is designed to be integrated directly with the arbiter agent codebase. Ensure that the arbiter agent's modules (particularly `app.core.cross_agent_comparison`) are available in the Python path. For testing purposes, a `test_api` has been created without cross_agent_comparison module.
 
 5. **Start the API server**
 
 ```bash
-python -m uvicorn vulnerability_submissions:app --reload
+python -m uvicorn submissions:app --reload
 ```
 
-This will start the server on http://127.0.0.1:8001
+OR for `test_api` 
+
+```bash
+python -m uvicorn test_api:app --reload
+```
+
+This will start the server on http://127.0.0.1:8000
 
 ## API Documentation
 
 Once the server is running, interactive API documentation is available at:
 
-- http://127.0.0.1:8001/docs
+- http://127.0.0.1:8000/docs
 
 ## API Endpoints
 

--- a/Demo/app/api/submissions/Readme.md
+++ b/Demo/app/api/submissions/Readme.md
@@ -1,0 +1,135 @@
+# Vulnerability Submissions API
+
+An API endpoint for security audit agents to submit vulnerability findings for smart contract audits. This API integrates directly with the cross-agent comparison system to process, deduplicate, and classify security findings.
+
+## Overview
+
+This API provides a standardized interface for audit agents to submit security vulnerabilities they discover during smart contract audits. Upon submission, each finding is:
+
+1. Validated against the project database to ensure it references an existing project
+2. Processed through the cross-agent comparison system
+3. Checked for duplicates against previous submissions
+4. Compared with findings from other agents to identify similar issues
+5. Classified and stored with appropriate metadata
+
+## Setup & Installation
+
+1. **Install dependencies**
+
+```bash
+pip install fastapi uvicorn pymongo python-dotenv pydantic
+```
+
+2. **Create a `.env` file**
+
+In the project directory, create a `.env` file with the following configuration:
+
+```
+# MongoDB connection
+MONGO_URI=mongodb://localhost:27017
+
+# Cross-agent comparison settings
+SIMILARITY_THRESHOLD=0.8
+```
+
+3. **Ensure MongoDB is running**
+
+The API requires MongoDB for task validation and finding storage.
+
+```bash
+# Check if MongoDB is running
+mongo --eval "db.version()" || mongosh --eval "db.version()"
+```
+
+4. **Integrate with arbiter agent code**
+
+This API is designed to be integrated directly with the arbiter agent codebase. Ensure that the arbiter agent's modules (particularly `app.core.cross_agent_comparison`) are available in the Python path.
+
+5. **Start the API server**
+
+```bash
+python -m uvicorn vulnerability_submissions:app --reload
+```
+
+This will start the server on http://127.0.0.1:8001
+
+## API Documentation
+
+Once the server is running, interactive API documentation is available at:
+
+- http://127.0.0.1:8001/docs
+
+## API Endpoints
+
+### Submit a vulnerability
+
+```
+POST /api/vulnerabilities
+```
+
+**Request Body:**
+
+```json
+{
+  "project_id": "project-123",
+  "reported_by_agent": "agent-456",
+  "finding_id": "finding-789",
+  "title": "Reentrancy vulnerability in withdraw function",
+  "description": "The withdraw function allows state changes after external calls, creating a potential reentrancy condition where an attacker can drain funds.",
+  "severity": "HIGH",
+  "recommendation": "Implement the checks-effects-interactions pattern by updating balances before making external calls.",
+  "code_references": ["contracts/Vault.sol:24", "contracts/Vault.sol:42"]
+}
+```
+
+**Response:**
+
+```json
+{
+  "message": "Vulnerability submitted and processed successfully",
+  "processing_results": {
+    "deduplication": {
+      "new_findings": 1,
+      "duplicates": 0,
+      "new_ids": ["finding-789"]
+    },
+    "cross_comparison": {
+      "total": 1,
+      "similar_valid": 0,
+      "pending_evaluation": 1,
+      "already_reported": 0,
+      "similar_ids": [],
+      "pending_ids": ["finding-789"]
+    }
+  }
+}
+```
+
+### Health check
+
+```
+GET /health
+```
+
+**Response:**
+
+```json
+{
+  "status": "healthy"
+}
+```
+
+## Security Finding Model
+
+Security findings must include the following fields:
+
+| Field             | Description                              |
+| ----------------- | ---------------------------------------- |
+| project_id        | Identifier of the audited project        |
+| reported_by_agent | Identifier of the audit agent            |
+| finding_id        | Unique identifier for the finding        |
+| title             | Concise description of the vulnerability |
+| description       | Detailed explanation with context        |
+| severity          | HIGH or MEDIUM                           |
+| recommendation    | Suggested fix or mitigation              |
+| code_references   | List of affected code locations          |

--- a/Demo/app/api/submissions/Readme.md
+++ b/Demo/app/api/submissions/Readme.md
@@ -34,7 +34,7 @@ SIMILARITY_THRESHOLD=0.8
 
 3. **Ensure MongoDB is running**
 
-The API requires MongoDB for task validation and finding storage.
+The API requires MongoDB for project validation and finding storage.
 
 ```bash
 # Check if MongoDB is running

--- a/Demo/app/api/submissions/seed_data.py
+++ b/Demo/app/api/submissions/seed_data.py
@@ -1,3 +1,5 @@
+# This script is for test purposes only.
+# It creates test data in the MongoDB database for the smart contract vulnerability submissions API.
 from pymongo import MongoClient
 from datetime import datetime
 

--- a/Demo/app/api/submissions/seed_data.py
+++ b/Demo/app/api/submissions/seed_data.py
@@ -1,0 +1,21 @@
+from pymongo import MongoClient
+from datetime import datetime
+
+# Connect to MongoDB
+client = MongoClient("mongodb://localhost:27017")
+db = client.get_database("smart_contract_db")
+
+# Drop existing collections to start fresh
+db.contracts.drop()
+
+# Create test contract
+db.contracts.insert_one({
+    "task_id": "project-123",  # Use the same ID you plan to use in your test request
+    "name": "TestContract",
+    "code": "contract Test { /* contract code here */ }",
+    "language": "Solidity",
+    "created_at": datetime.utcnow().isoformat(),
+    "updated_at": datetime.utcnow().isoformat()
+})
+
+print("Test data created successfully!")

--- a/Demo/app/api/submissions/submissions.py
+++ b/Demo/app/api/submissions/submissions.py
@@ -1,0 +1,124 @@
+from fastapi import FastAPI, HTTPException, Body
+from typing import Dict, Any, List
+from pydantic import BaseModel
+from enum import Enum
+import os
+from dotenv import load_dotenv
+import re
+from pymongo import MongoClient
+
+from app.core.cross_agent_comparison import CrossAgentComparison
+
+# Load environment variables
+load_dotenv()
+
+# Initialize FastAPI app
+app = FastAPI(
+    title="Smart Contract Vulnerability Submissions API",
+    description="API for submitting vulnerability findings for security assessment",
+    version="1.0.0"
+)
+
+# MongoDB connection for validating task existence
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+client = MongoClient(MONGO_URI)
+db = client.get_database("smart_contract_db")
+contracts_collection = db.get_collection("contracts")
+
+# Define severity levels according to security standards
+
+
+class Severity(str, Enum):
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+
+# Pydantic model for vulnerability submission validation
+
+
+class FindingInput(BaseModel):
+    """
+    Model representing a security finding submission with all required fields
+    for vulnerability assessment and processing.
+    """
+    project_id: str          # Unique identifier for the audited project
+    reported_by_agent: str   # Identifier of the agent reporting the vulnerability
+    finding_id: str          # Unique identifier for this finding
+    title: str               # Short descriptive title of the vulnerability
+    description: str         # Detailed explanation of the vulnerability
+    severity: Severity       # Severity rating (HIGH or MEDIUM)
+    recommendation: str      # Suggested fix or mitigation
+    code_references: List[str]  # List of affected code locations
+
+# API endpoints
+
+
+@app.post("/api/vulnerabilities", response_model=Dict[str, Any], tags=["Vulnerabilities"])
+async def submit_vulnerability(
+    submission: FindingInput = Body(...),
+):
+    """
+    Submit a vulnerability finding for processing and storage.
+
+    This endpoint:
+    1. Validates that the referenced project exists
+    2. Processes the finding through the cross-agent comparison system
+    3. Returns detailed results of deduplication and validation
+
+    The finding is checked against previously reported issues to identify
+    duplicates and similar vulnerabilities from other agents.
+    """
+    # Verify the referenced project exists before accepting the submission
+    contract = contracts_collection.find_one(
+        {"task_id": {"$regex": f"^{re.escape(submission.project_id)}$", "$options": "i"}})
+    if not contract:
+        raise HTTPException(
+            status_code=404, detail=f"Contract with project ID {submission.project_id} not found")
+
+    try:
+        # Initialize the cross-agent comparison module
+        # This handles deduplication, similarity checks, and status determination
+        comparison = CrossAgentComparison()
+
+        # Process the new finding
+        # This will:
+        # - Check for duplicates within this agent's submissions
+        # - Compare with findings from other agents
+        # - Assign appropriate status (unique, duplicate, similar)
+        # - Store the finding with proper metadata
+        result = await comparison.process_new_findings(
+            project_id=submission.project_id,
+            agent_id=submission.reported_by_agent,
+            # Pass as a list since the method expects multiple findings
+            new_findings=[submission]
+        )
+
+        return {
+            "message": "Vulnerability submitted and processed successfully",
+            "processing_results": result
+        }
+
+    except Exception as e:
+        # Handle unexpected errors during processing
+        raise HTTPException(
+            status_code=500,
+            detail=f"Processing error: {str(e)}"
+        )
+
+# Health check endpoint
+
+
+@app.get("/health", tags=["Health"])
+async def health_check():
+    """
+    Health check endpoint to verify the API is running.
+
+    Returns a simple status indicator that can be used by monitoring tools
+    to confirm the service is operational.
+    """
+    return {"status": "healthy"}
+
+# Run the application with uvicorn when executed directly
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("vulnerability_submissions:app",
+                host="0.0.0.0", port=8001, reload=True)

--- a/Demo/app/api/submissions/submissions.py
+++ b/Demo/app/api/submissions/submissions.py
@@ -7,6 +7,10 @@ from dotenv import load_dotenv
 import re
 from pymongo import MongoClient
 
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 from app.core.cross_agent_comparison import CrossAgentComparison
 
 # Load environment variables
@@ -120,5 +124,5 @@ async def health_check():
 # Run the application with uvicorn when executed directly
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("vulnerability_submissions:app",
+    uvicorn.run("submissions:app",
                 host="0.0.0.0", port=8001, reload=True)

--- a/Demo/app/api/submissions/test_api.py
+++ b/Demo/app/api/submissions/test_api.py
@@ -1,0 +1,104 @@
+# This is a test submissions API without integration with the cross-agent comparison system.
+# It is designed to accept vulnerability findings and validate the existence of the referenced project.
+# The API is structured to allow for easy integration with a cross-agent comparison system in the future.
+# The API uses MongoDB for data storage and retrieval, and Pydantic for data validation.
+
+
+from fastapi import FastAPI, HTTPException, Body
+from typing import Dict, Any, List
+from pydantic import BaseModel
+from enum import Enum
+import os
+from dotenv import load_dotenv
+import re
+from datetime import datetime
+from pymongo import MongoClient
+
+# Load environment variables
+load_dotenv()
+
+# Initialize FastAPI app
+app = FastAPI(
+    title="Smart Contract Vulnerability Submissions API",
+    description="API for submitting vulnerability findings for security assessment",
+    version="1.0.0"
+)
+
+# MongoDB connection for validating task existence
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+client = MongoClient(MONGO_URI)
+db = client.get_database("smart_contract_db")
+contracts_collection = db.get_collection("contracts")
+
+# Define severity levels according to security standards
+class Severity(str, Enum):
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+
+# Pydantic model for vulnerability submission validation
+class FindingInput(BaseModel):
+    """Model representing a security finding submission"""
+    project_id: str
+    reported_by_agent: str
+    finding_id: str
+    title: str
+    description: str
+    severity: Severity
+    recommendation: str
+    code_references: List[str]
+
+# API endpoints
+@app.post("/api/vulnerabilities", response_model=Dict[str, Any], tags=["Vulnerabilities"])
+async def submit_vulnerability(
+    submission: FindingInput = Body(...),
+):
+    """
+    Submit a vulnerability finding for processing.
+    """
+    # Verify the referenced project exists
+    contract = contracts_collection.find_one(
+        {"task_id": {"$regex": f"^{re.escape(submission.project_id)}$", "$options": "i"}})
+    if not contract:
+        raise HTTPException(
+            status_code=404, detail=f"Contract with project ID {submission.project_id} not found")
+
+    try:
+        # In the actual implementation, this would call the arbiter agent's processing
+        # For testing, we'll just return a mock response
+        return {
+            "message": "Vulnerability submitted and processed successfully",
+            "processing_results": {
+                "deduplication": {
+                    "new_findings": 1,
+                    "duplicates": 0,
+                    "new_ids": [submission.finding_id]
+                },
+                "cross_comparison": {
+                    "total": 1,
+                    "similar_valid": 0,
+                    "pending_evaluation": 1,
+                    "already_reported": 0,
+                    "similar_ids": [],
+                    "pending_ids": [submission.finding_id]
+                }
+            }
+        }
+        
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Processing error: {str(e)}"
+        )
+
+# Health check endpoint
+@app.get("/health", tags=["Health"])
+async def health_check():
+    """
+    Health check endpoint to verify the API is running.
+    """
+    return {"status": "healthy"}
+
+# Run the application with uvicorn
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("test_api:app", host="0.0.0.0", port=8001, reload=True)


### PR DESCRIPTION
This PR add submissions API to arbiter agent. The schema has been made to match the current arbiter agent setup and the submissions API calls relevant function from the arbiter agent.

`seed_data.py` and `test_api.py` are for test purposes only. 

Please refer to `readme` for more details.

Video demonstrating the API:

https://github.com/user-attachments/assets/71220b11-ee1c-4ca2-9dc7-b04019b1c512

