### PR TITLE
Upgrade default claude model to the latest one

### DIFF
--- a/Demo/.env.example
+++ b/Demo/.env.example
@@ -3,7 +3,7 @@ MONGODB_URL=mongodb://localhost:27017
 
 # Claude API configuration
 CLAUDE_API_KEY=sk-ant-your-api-key-here
-CLAUDE_MODEL=claude-3-opus-20240229
+CLAUDE_MODEL=claude-3-7-sonnet-latest
 CLAUDE_TEMPERATURE=0.0
 CLAUDE_MAX_TOKENS=1000
 

--- a/Demo/app/core/claude_model.py
+++ b/Demo/app/core/claude_model.py
@@ -13,7 +13,7 @@ from langchain.chains import LLMChain
 load_dotenv()
 
 # Default values
-DEFAULT_MODEL = "claude-3-opus-20240229"
+DEFAULT_MODEL = "claude-3-7-sonnet-latest"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_MAX_TOKENS = 1000
 

--- a/Demo/app/core/final_evaluation.py
+++ b/Demo/app/core/final_evaluation.py
@@ -15,6 +15,7 @@ from langchain.chains import LLMChain
 from app.database.mongodb_handler import mongodb
 from app.models.finding_db import FindingDB, Status, EvaluatedSeverity
 from app.core.cross_agent_comparison import CrossAgentComparison
+from app.core.claude_model import create_claude_model
 
 class FindingEvaluator:
     """
@@ -40,17 +41,8 @@ class FindingEvaluator:
         Returns:
             LLMChain configured to evaluate findings
         """
-        # Get API key directly from environment
-        api_key = os.getenv("CLAUDE_API_KEY")
-        if not api_key:
-            raise ValueError("CLAUDE_API_KEY environment variable is not set")
-        
-        # Initialize Claude model
-        model = ChatAnthropic(
-            model="claude-3-opus-20240229",
-            anthropic_api_key=api_key,
-            temperature=0
-        )
+        # Initialize Claude model using centralized configuration
+        model = create_claude_model()
         
         # Create evaluation prompt template focused on smart contract vulnerabilities
         evaluation_template = """


### PR DESCRIPTION
I simply upgrade the default claude model to `claude-3-7-sonnet-latest`. I also noticed some environment values used in `conf.py` is not defined in `.env`. Is it intentionally for some demo purpose? @andrewtookay 